### PR TITLE
chore: add release tasks for builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,6 @@ gemspec
 
 group :development do
   gem "pry"
+  gem 'conventional-changelog', '~> 1.3'
+  gem 'bump', '~> 0.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,25 +10,27 @@ GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.8.0)
+    bump (0.8.0)
     coderay (1.1.2)
+    conventional-changelog (1.3.0)
     diff-lcs (1.3)
-    faraday (0.15.4)
+    faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    httparty (0.17.0)
+    httparty (0.17.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     json (2.2.0)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.1009)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    pact (1.41.0)
+    pact (1.42.0)
       json (> 1.8.5)
       pact-mock_service (~> 3.0)
       pact-support (~> 1.9)
@@ -63,15 +65,12 @@ GEM
       rake (~> 10.4, >= 10.4.2)
       rspec (~> 3.5)
       rspec_junit_formatter (~> 0.3)
-    pact-support (1.11.0)
+    pact-support (1.12.0)
       awesome_print (~> 1.1)
-      find_a_port (~> 1.0.1)
-      json
       randexp (~> 0.1.7)
       rspec (>= 2.14)
       term-ansicolor (~> 1.0)
-      thor
-    pact_broker-client (1.19.0)
+    pact_broker-client (1.20.0)
       httparty
       json
       rake
@@ -91,37 +90,39 @@ GEM
       rack (>= 1.0, < 3)
     rake (10.5.0)
     randexp (0.1.7)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.1)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.1)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.2)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     table_print (1.5.6)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (0.20.3)
-    tins (1.20.3)
-    webrick (1.4.2)
+    tins (1.21.1)
+    webrick (1.5.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bump (~> 0.5)
   bundler (~> 1.16)
+  conventional-changelog (~> 1.3)
   pact-cli!
   pry
   rake (~> 10.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,6 @@
+# Releasing
+
+Run:
+
+    chruby 2.4 #or whatever your version manager is
+    script/release.sh [major|minor|patch] # default is minor

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+Dir.glob('./tasks/**/*.rake').each { |task| load task }
+
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+unset X_PACT_DEVELOPMENT
+
+git pull origin master
+
+bundle exec rake package:update
+
+if git log -1 | grep "feat(gems)"; then
+  bundle exec bump ${1:-minor} --no-commit
+  bundle exec rake generate_changelog
+  git add lib/pact/cli/version.rb
+  git commit -m "chore(release): version $(cat VERSION)" && git push origin master
+  bundle exec rake tag_for_release
+else
+  echo "No gems updated, not releasing"
+fi

--- a/tasks/package_update.rake
+++ b/tasks/package_update.rake
@@ -1,0 +1,43 @@
+module PactRubyCli
+
+  extend self
+
+  def update
+    Bundler.with_clean_env do
+      output = `bundle update 2>&1`
+      $stdout.puts output
+      if $? == 0
+        commit(commit_message(output))
+      else
+        $stderr.puts "Error updating bundle"
+      end
+    end
+  end
+
+  def commit(message)
+    "git add .".tap { |it| puts it }.tap { |it| system it }
+    "git commit -m \"#{message}\"".tap { |it| puts it }.tap { |it| system it }
+  end
+
+  def commit_message(output)
+    pact_updates = output
+      .split("\n")
+      .select{|l|l =~ /pact.*\(was\s/}
+      .collect(&:split)
+      .collect{|w| "#{w[1]} #{w[2]}"}
+      .uniq
+      .join(", ")
+
+    if pact_updates.size > 0
+      "feat(gems): update to #{pact_updates}"
+    else
+      "feat(gems): update non-pact gems"
+    end
+  end
+end
+
+namespace :package do
+  task :update do
+    PactRubyCli.update
+  end
+end

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,0 +1,13 @@
+desc 'Generate change log'
+task :generate_changelog do
+  require 'conventional_changelog'
+  version = File.read('VERSION')
+  ConventionalChangelog::Generator.new.generate! version: "v#{version}"
+end
+
+desc 'Tag for release'
+task :tag_for_release do | t, args |
+  command = "git tag -a v#{VERSION} -m \"chore(release): version #{VERSION}\" && git push origin v#{VERSION}"
+  puts command
+  puts `#{command}`
+end


### PR DESCRIPTION
The docker build in https://hub.docker.com/r/pactfoundation/pact-cli would need to be updated as well, I think

fixes: https://github.com/pact-foundation/pact-ruby-cli/issues/3