### PR TITLE
Update readme: fix that git url become mailto: link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run --rm  \
 
 ### Publish pacts from host machine
 
-You can clone git@github.com:pact-foundation/pact-ruby-cli.git and run the following from the root directory.
+You can clone `git@github.com:pact-foundation/pact-ruby-cli.git` and run the following from the root directory.
 
 ```
 docker run --rm \


### PR DESCRIPTION
Fix the url of the git repo that become mail link in Chrome

![Screen Shot 2019-10-27 at 17 47 49](https://user-images.githubusercontent.com/686676/67633393-eda73880-f8e1-11e9-9368-88ea6bc0b012.png)

to

![Screen Shot 2019-10-27 at 17 48 55](https://user-images.githubusercontent.com/686676/67633408-10d1e800-f8e2-11e9-9069-f01c5e3088c0.png)
