### PR TITLE
feat: allow non pact commands to be specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,4 @@ ADD lib ./lib
 ADD example/pacts ./example/pacts
 
 ENTRYPOINT ["/pact/entrypoint.sh"]
+CMD ["pact"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
-# Make the pact content dynamic so a new version gets published every time
-if echo "$@" | grep "/pact/example/pacts" >/dev/null 2>&1 ; then
-  echo "Generating a new version of the pact for this demo"
-  cat /pact/example/pacts/pact.json | sed "s/\"1\"/\"$(date +%s)\"/g" > /tmp/pact.json
-  mv /tmp/pact.json /pact/example/pacts/pact.json
-fi
+PACT_COMMANDS=" broker help mock-service publish stub-service verify version "
 
-pact "$@"
+if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " 2>&1 ; then
+  # Make the pact content dynamic so a new version gets published every time
+  if echo "$@" | grep "/pact/example/pacts" >/dev/null 2>&1 ; then
+    echo "Generating a new version of the pact for this demo"
+    cat /pact/example/pacts/pact.json | sed "s/\"1\"/\"$(date +%s)\"/g" > /tmp/pact.json
+    mv /tmp/pact.json /pact/example/pacts/pact.json
+  fi
+
+  pact "$@"
+else
+  exec "$@"
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 PACT_COMMANDS=" broker help mock-service publish stub-service verify version "
 
-if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " 2>&1 ; then
+if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
   # Make the pact content dynamic so a new version gets published every time
   if echo "$@" | grep "/pact/example/pacts" >/dev/null 2>&1 ; then
     echo "Generating a new version of the pact for this demo"


### PR DESCRIPTION
Implement entrypoint as per https://github.com/docker-library/official-images#consistency

```
$ docker run --rm pactfoundation/pact-cli help
Commands:
   broker                          # Interact with a Pact Broker
   help [COMMAND]                  # Describe available commands or one speci...
   mock-service                    # Run a Pact mock service
   publish PACT_DIRS_OR_FILES ...  # Publish pacts to a Pact Broker.
   stub-service                    # Run a Pact stub service
   verify PACT_URL ...             # Verify pact(s) against a provider. Suppo...
   version                         # Print the version
```

```
$ docker run --rm pactfoundation/pact-cli pact help broker
Commands:
  broker can-i-deploy -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BRO...
  broker create-environment --name=NAME -b, --broker-base-url=BROKER_BASE_URL...
  broker create-or-update-pacticipant --name=NAME -b, --broker-base-url=BROKE...
  ...
```

```
$ docker run --rm pactfoundation/pact-cli pact help
Commands:
   broker                          # Interact with a Pact Broker
   help [COMMAND]                  # Describe available commands or one speci...
   mock-service                    # Run a Pact mock service
   publish PACT_DIRS_OR_FILES ...  # Publish pacts to a Pact Broker.
   stub-service                    # Run a Pact stub service
   verify PACT_URL ...             # Verify pact(s) against a provider. Suppo...
   version                         # Print the version
```

```
$ docker run --rm pactfoundation/pact-cli sh -c 'ls'
Gemfile
Gemfile.lock
bin
entrypoint.sh
example
lib
pact-cli.gemspec
```

```
$ docker run --rm pactfoundation/pact-cli ls
Gemfile
Gemfile.lock
bin
entrypoint.sh
example
lib
pact-cli.gemspec
```