### PR TITLE
fix: Ran bundle install with same bundler version as dockerfile (2.2.20)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     awesome_print (1.9.2)
     bump (0.10.0)
     coderay (1.1.3)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     dig_rb (1.0.1)
     expgen (0.1.1)
       parslet
@@ -151,4 +151,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.20


### PR DESCRIPTION
Currently the gemfile.lock is bundled with 2.1.4, this is causing issues to show up when performing security scans on the pact-cli docker image due to [CVE-2020-36327](https://nvd.nist.gov/vuln/detail/CVE-2020-36327) and [CVE-2021-43809](https://nvd.nist.gov/vuln/detail/CVE-2021-43809)

To fix this, I simply re-ran bundle install with the same bundler version as specified in the Dockerfile (2.2.20)