### PR TITLE
fix: branch detection fix in response git cve fix

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,11 @@
 
 PACT_COMMANDS=" broker help mock-service publish stub-service verify version "
 
+# git branch detection command fails due to cve fix https://github.blog/2022-04-12-git-security-vulnerability-announced/
+# fatal: unsafe repository (REPO is owned by someone else) in other workflow steps after running checkout
+# https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "*" 
+
 if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
   # Make the pact content dynamic so a new version gets published every time
   if echo "$@" | grep "/pact/example/pacts" >/dev/null 2>&1 ; then


### PR DESCRIPTION
git branch detection command fails due to cve fix https://github.blog/2022-04-12-git-security-vulnerability-announced/

> fatal: unsafe repository (REPO is owned by someone else) in other workflow steps after running checkout

https://github.com/actions/checkout/issues/766

fixes #78 


Failing run from latest of the official image

https://github.com/pactflow/actions/actions/runs/3201040361/jobs/5228627393#step:3:98

Passing run with the fix from this branch, built and uploaded as `you54f:pact-cli:latest`

https://github.com/pactflow/actions/actions/runs/3204506236/jobs/5235884881#step:3:101

diff:- https://github.com/pactflow/actions/compare/main...test_git_safe_dir_issue