### PR TITLE
Add URL to proposed to be cloned repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Commands:
 
 ### Publish pacts
 
-You can clone `git@github.com:pact-foundation/pact-ruby-cli.git` and run the following from the root directory.
+You can clone `git@github.com:pact-foundation/pact-ruby-cli.git` (https://github.com/pact-foundation/pact-ruby-cli) and run the following from the root directory.
 
 ```
 docker run --rm \


### PR DESCRIPTION
While reading docs from https://hub.docker.com/r/pactfoundation/pact-cli I stopped reading on 'publish pacts' chapter and think about what repository is proposed for me to clone.
I think added URL makes it easier to know about future cloning results.