### PR TITLE
feat: add plugin cli to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.15
 
 LABEL maintainer="Beth Skurrie <beth@bethesque.com>"
 
+ARG PLUGIN_CLI_VERSION=0.0.2
+
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
@@ -52,6 +54,9 @@ ADD docker/entrypoint.sh $HOME/entrypoint.sh
 ADD bin ./bin
 ADD lib ./lib
 ADD example/pacts ./example/pacts
+
+ADD https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${PLUGIN_CLI_VERSION}/pact-plugin-cli-linux-x86_64.gz ./bin
+RUN gunzip -fc ./bin/pact-plugin-cli-linux-x86_64.gz > ./bin/pact-plugin-cli && chmod +x ./bin/pact-plugin-cli
 
 ENTRYPOINT ["/pact/entrypoint.sh"]
 CMD ["pact"]


### PR DESCRIPTION
This adds the plugin CLI into the docker image.

However, I don't think this is useful. By default, it will install any plugin into the container, which is not what anyone would want. Users will need to mount the plugin installation directory and then set an environment variable just to get it to work. And it will then only install the Linux version of the plugins.