### PR TITLE
chore: add audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,22 @@
+name: Audit
+
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+    - cron: 0 0 * * 4 # Midnight Wednesday
+
+jobs:
+  audit:
+    name: 💥 audit
+    strategy:
+      fail-fast: false
+      matrix:
+        DOCKER_TARGET_PLATFORM: [linux/amd64]
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TARGET_PLATFORM: ${{ matrix.DOCKER_TARGET_PLATFORM }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Audit Docker image for ${{ matrix.DOCKER_TARGET_PLATFORM }}
+        run: ./script/release-workflow/audit.sh

--- a/script/release-workflow/audit.sh
+++ b/script/release-workflow/audit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo >/dev/null
+
+script_dir=$(cd "$(dirname $0)" && pwd)
+
+. ${script_dir}/set-env-vars.sh
+
+${script_dir}/docker-build.sh
+${script_dir}/scan.sh


### PR DESCRIPTION
as per https://github.com/pact-foundation/pact-broker-docker/pull/128 && https://github.com/pact-foundation/pact-broker-docker/pull/130 - add an audit job on a cron, so we don't just find out at release time