### PR TITLE
chore: update CHANGELOG to reflect 0.51.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="0.51.0.4"></a>
 ### 0.51.0.4 (2023-05-18)
 
+#### Features
+
+* Multi manifest build - arm64/arm (new) + amd64 (current)	 ([944b799](/../../commit/944b799))
+
 <a name="0.51.0.3"></a>
 ### 0.51.0.3 (2023-05-17)
 


### PR DESCRIPTION
I think due to #109 where I reverted, a revert to rewrite a squashed commit message, to include `feat: ...` it wasn't picked up in the `CHANGELOG`.

This retrospectively adds the information into the `CHANGELOG`