### PR TITLE
chore(examples): ruby:3.1-alpine image, pin rack 2.2.7, add webrick 1…

### DIFF
--- a/docker-compose-verify.yml
+++ b/docker-compose-verify.yml
@@ -2,12 +2,12 @@ version: "3"
 
 services:
   api:
-    image: ruby:2.5-alpine
+    image: ruby:3.1-alpine
     environment:
       # Setting the response body as an environment variable is just a way
       # to get around the multiple layers of nested quotes in the command!
       RESPONSE_BODY: "{\"id\": \"1\", \"name\": \"Foo\"}"
-    command: sh -c "gem install rack && rackup -o 0.0.0.0 -b \"run ->(env){ [200, {'Content-Type' => 'application/json'}, [ENV['RESPONSE_BODY']]] }\""
+    command: sh -c "gem install webrick -v 1.8.1 && gem install rack -v 2.2.7 && rackup -o 0.0.0.0 -b \"run ->(env){ [200, {'Content-Type' => 'application/json'}, [ENV['RESPONSE_BODY']]] }\""
     expose:
       - "9292"
 
@@ -28,4 +28,4 @@ services:
       --provider docker-example-provider
       --provider-app-version ${GIT_COMMIT}
       --provider-version-tag ${GIT_BRANCH}
-      --wait 10
+      --wait 20


### PR DESCRIPTION
….8.1, fixes #82

- Updates verifier image to use ruby:3.1-alpine image
- Pins rack to 2.2.7
- Pins webrick to 1.8.1, required for rack

```sh
 ✔ Network pact-ruby-cli_default            Created                                                                                                                    0.0s 
 ✔ Container pact-ruby-cli-api-1            Created                                                                                                                    0.3s 
 ✔ Container pact-ruby-cli-pact_verifier-1  Created                                                                                                                    0.0s 
Attaching to pact-ruby-cli-api-1, pact-ruby-cli-pact_verifier-1
pact-ruby-cli-api-1            | Successfully installed webrick-1.8.1
pact-ruby-cli-api-1            | 1 gem installed
pact-ruby-cli-api-1            | Successfully installed rack-2.2.7
pact-ruby-cli-api-1            | 1 gem installed
pact-ruby-cli-api-1            | [2023-05-19 09:06:36] INFO  WEBrick 1.8.1
pact-ruby-cli-api-1            | [2023-05-19 09:06:36] INFO  ruby 3.1.4 (2023-03-30) [x86_64-linux-musl]
pact-ruby-cli-api-1            | [2023-05-19 09:06:36] INFO  WEBrick::HTTPServer#start: pid=1 port=9292
pact-ruby-cli-pact_verifier-1  | INFO: Polling for up to 20 seconds for provider to become available at api:9292...
pact-ruby-cli-pact_verifier-1  | INFO: Provider available, proceeding with verifications
pact-ruby-cli-pact_verifier-1  | INFO: Fetching pacts for docker-example-provider from https://test.pactflow.io with the selection criteria: 
pact-ruby-cli-pact_verifier-1  | pact WARN: Please note: we are tracking events anonymously to gather important usage statistics like Pact-Ruby version
pact-ruby-cli-pact_verifier-1  |               and operating system. To disable tracking, set the 'PACT_DO_NOT_TRACK' environment
pact-ruby-cli-pact_verifier-1  |               variable to 'true'.
pact-ruby-cli-pact_verifier-1  | INFO: Reading pact at https://dXfltyFMgNOFZAxr8io9wJ37iUpY42M:*****@test.pactflow.io/pacts/provider/docker-example-provider/consumer/docker-example-consumer/pact-version/824bd50042395c6457b15cfc73fdd06e43e17d65/metadata/c1tdW2N2XT01NDk4NQ
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | DEBUG: The pact at https://test.pactflow.io/pacts/provider/docker-example-provider/consumer/docker-example-consumer/pact-version/824bd50042395c6457b15cfc73fdd06e43e17d65 is being verified because the pact content belongs to the consumer version matching the following criterion:
pact-ruby-cli-pact_verifier-1  |     * latest version of docker-example-consumer from the main branch 'master' (fake-git-sha-for-demo-1671052958)
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | Verifying a pact between docker-example-consumer and docker-example-provider
pact-ruby-cli-pact_verifier-1  |   Given bar exists
pact-ruby-cli-pact_verifier-1  |     a request for bar
pact-ruby-cli-pact_verifier-1  |       with GET /bar
pact-ruby-cli-pact_verifier-1  |         returns a response which
pact-ruby-cli-pact_verifier-1  | WARN: Skipping set up for provider state 'bar exists' for consumer 'docker-example-consumer' as there is no --provider-states-setup-url specified.
pact-ruby-cli-pact_verifier-1  |           has status code 200
pact-ruby-cli-api-1            | 127.0.0.1 - - [19/May/2023:09:06:38 +0000] "GET /bar HTTP/1.1" 200 26 0.0030
pact-ruby-cli-pact_verifier-1  |           has a matching body (FAILED - 1)
pact-ruby-cli-pact_verifier-1  |           includes headers
pact-ruby-cli-pact_verifier-1  |             "Content-Type" which equals "application/json"
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | Failures:
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  |   1) Verifying a pact between docker-example-consumer and docker-example-provider Given bar exists a request for bar with GET /bar returns a response which has a matching body
pact-ruby-cli-pact_verifier-1  |      Failure/Error: expect(response_body).to match_term expected_response_body, diff_options, example
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  |        Actual: {"id":"1","name":"Foo"}
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  |        Diff
pact-ruby-cli-pact_verifier-1  |        --------------------------------------
pact-ruby-cli-pact_verifier-1  |        Key: - is expected 
pact-ruby-cli-pact_verifier-1  |             + is actual 
pact-ruby-cli-pact_verifier-1  |        Matching keys and values are not shown
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  |         {
pact-ruby-cli-pact_verifier-1  |        -  "name": "Bar"
pact-ruby-cli-pact_verifier-1  |        +  "name": "Foo"
pact-ruby-cli-pact_verifier-1  |         }
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  |        Description of differences
pact-ruby-cli-pact_verifier-1  |        --------------------------------------
pact-ruby-cli-pact_verifier-1  |        * Expected "Bar" but got "Foo" at $.name
pact-ruby-cli-pact_verifier-1  |      # ./bin/pact:15:in `<top (required)>'
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | 1 interaction, 1 failure
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | Failed interactions:
pact-ruby-cli-pact_verifier-1  | 
pact-ruby-cli-pact_verifier-1  | PACT_DESCRIPTION="a request for bar" PACT_PROVIDER_STATE="bar exists" /pact/bin/pact verify https://dXfltyFMgNOFZAxr8io9wJ37iUpY42M:*****@test.pactflow.io/pacts/provider/docker-example-provider/consumer/docker-example-consumer/pact-version/824bd50042395c6457b15cfc73fdd06e43e17d65/metadata/c1tdW2N2XT01NDk4NQ --provider-base-url http://api:9292 --provider docker-example-provider --provider-app-version fake-git-sha-for-demo1684487187 --provider-version-tag master --wait 20 # A request for bar given bar exists
```