### PR TITLE
Chore/node update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        node: [ 14, 15, 16, 17, 18, 19, 20 ]
+        node: [ 16, 18, 20 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
 
       - name: Login to Docker Hub

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -29,7 +29,7 @@ RUN apk update \
              libressl-dev \
              ruby-rdoc \
   \
-  && gem install bundler -v 2.4 \
+  && gem install bundler -v 2.4.12 \
   && bundler -v \
   && bundle config build.nokogiri --use-system-libraries \
   && bundle config git.allow_insecure true \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=14
+ARG NODE_VERSION=18
 FROM node:${NODE_VERSION}-alpine3.17
 
 LABEL maintainer="Beth Skurrie <beth@bethesque.com>"
@@ -29,7 +29,7 @@ RUN apk update \
              libressl-dev \
              ruby-rdoc \
   \
-  && gem install bundler -v 2.4.12 \
+  && gem install bundler -v 2.4 \
   && bundler -v \
   && bundle config build.nokogiri --use-system-libraries \
   && bundle config git.allow_insecure true \


### PR DESCRIPTION
- Updates default node version in Dockerfile to LTS version `18`
- Drops non LTS and unsupported versions of node from testing matrix

See https://endoflife.date/nodejs for current EOL dates for node
