### PR TITLE
chore(ci): audit - only build indiv images per audit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   DOCKER_IMAGE_ORG_AND_NAME: pactfoundation/pact-cli
-  TAG: $CIRRUS_TAG
+  DOCKER_TARGET_PLATFORM: linux/arm64
 
 linux_arm64_build_test_task: 
   compute_engine_instance:
@@ -8,7 +8,12 @@ linux_arm64_build_test_task:
     image: family/docker-builder-arm64
     architecture: arm64
     platform: linux
-    cpu: 4
-    memory: 16G
-  script:
-    - script/test.sh
+    cpu: 2
+    memory: 4G
+  pre_req_script: |
+      apt update --yes && apt install --yes jq
+      ./script/release-workflow/docker-prepare.sh
+  build_audit_script: |
+      ./script/release-workflow/audit.sh
+  test_script: |
+      ./script/test.sh

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   audit:
-    name: 💥 audit
+    name: 👮 audit
     strategy:
       fail-fast: false
       matrix:
@@ -23,18 +23,3 @@ jobs:
         run: ./script/release-workflow/docker-prepare.sh
       - name: Audit Docker image for ${{ matrix.DOCKER_TARGET_PLATFORM }}
         run: ./script/release-workflow/audit.sh
-      # # We could also run via a trivy action and publish results back to GitHub :)
-      # - name: Run Trivy vulnerability scanner for ${{ matrix.DOCKER_TARGET_PLATFORM }}
-      #   uses: aquasecurity/trivy-action@master
-      #   with:
-      #     image-ref: 'pactfoundation/pact-broker:audit'
-      #     exit-code: '1'
-      #     format: 'sarif'
-      #     output: 'trivy-results.sarif'
-      #     ignore-unfixed: true
-      #     vuln-type: 'os,library'
-      #     severity: 'CRITICAL,HIGH'
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v2
-      #   with:
-      #     sarif_file: 'trivy-results.sarif'

--- a/script/release-workflow/docker-build.sh
+++ b/script/release-workflow/docker-build.sh
@@ -5,7 +5,7 @@ set -euo >/dev/null
 ## This will allow for local use for testing or scanning with trivy (multi-manifest builds cannot be imported)
 ## we will build a multi-manifest build during ./docker-push.sh
 
-for arch in amd64 arm64 arm; do 
+for arch in $ARCHES; do 
     docker buildx build \
     --platform linux/$arch \
     --output type=docker \

--- a/script/release-workflow/scan.sh
+++ b/script/release-workflow/scan.sh
@@ -2,13 +2,11 @@
 
 set -eu
 
-SCRIPT_DIR=$(cd "$(dirname $0)"/.. && pwd)
-
-for arch in amd64; do 
-    docker run --rm \
-      -v ${PWD}/script/scan-inside-docker-container.sh:/pact/scan-inside-docker-container.sh \
-      -u root \
-      --entrypoint /bin/sh \
-      "${DOCKER_IMAGE_ORG_AND_NAME}:latest-${arch}" \
-      /pact/scan-inside-docker-container.sh
-done
+ARCH=${ARCH:-'amd64'}
+docker run --rm \
+  --platform=linux/${ARCH} \
+  -v ${PWD}/script/scan-inside-docker-container.sh:/pact/scan-inside-docker-container.sh \
+  -u root \
+  --entrypoint /bin/sh \
+  "${DOCKER_IMAGE_ORG_AND_NAME}:latest-${ARCH}" \
+  /pact/scan-inside-docker-container.sh

--- a/script/release-workflow/set-env-vars.sh
+++ b/script/release-workflow/set-env-vars.sh
@@ -2,7 +2,15 @@
 
 set -e
 
-export DOCKER_IMAGE_ORG_AND_NAME=pactfoundation/pact-cli
+export DOCKER_IMAGE_ORG_AND_NAME=${DOCKER_IMAGE_ORG_AND_NAME:-'pact-foundation/pact-cli'}
+if [ -n "${DOCKER_TARGET_PLATFORM:-}" ]; then
+    export ARCH=$(echo "$DOCKER_TARGET_PLATFORM" | sed 's/linux\///' | sed 's/\/v.*//')
+    export ARCHES="$ARCH"
+    export $ARCHES
+else 
+    export ARCHES='amd64 arm64 arm'
+    export ARCH=amd64
+fi
 
 if [ -n "${CUSTOM_TAG:-}" ]; then
   export TAG=$CUSTOM_TAG


### PR DESCRIPTION
Currently the audit step is building every architecture image, and then using the host platform to scan each image, the host platform is amd64, meaning we aren't using the native arm, or arm64 scanner from trivy, to scan the the images.

This change ensures that for each audit job
- we only build the `latest-${ARCH}` image if the `DOCKER_TARGET_PLATFORM` is set (it is set in the audits)
- otherwise we build all images, and only scan the `amd64` image on release.