### PR TITLE
feat(ci): additionally publish images to ghcr.io

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Bundle install
         run: bundle install
 
+      - name: Log into ghcr registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release image
         run: script/release-workflow/run.sh
         env:

--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -2,21 +2,29 @@
 
 set -euo >/dev/null
 
+## Publish a multi arch build
+## ($TAG||$MAJOR_TAG||$LATEST)
 push() {
+  ## These will use cached builds, so wont build every time.
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
     --output=type=image,push=true \
     -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
+}
+push_ghcr() {
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
   --output=type=image,push=true \
-  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
+  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME}:$1 
 }
 
 if [ -n "${MAJOR_TAG:-}" ]; then
   push ${MAJOR_TAG}
+  push_ghcr ${MAJOR_TAG}
 fi
 
 push ${TAG}
+push_ghcr ${TAG}
 
 if [ "${PUSH_TO_LATEST}" != "false" ]; then
   push latest
+  push_ghcr latest
 fi

--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -6,6 +6,9 @@ push() {
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
     --output=type=image,push=true \
     -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
+  docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
+  --output=type=image,push=true \
+  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
 }
 
 if [ -n "${MAJOR_TAG:-}" ]; then


### PR DESCRIPTION
Relates to https://github.com/pact-foundation/pact-stub-server/issues/61

It would be beneficial to users to publish our images to GitHub container registry. It doesn't require much additional effort so this is the first PR across the repos/images we currently publish. 

Tested on my fork and published to my packages 👇🏾 

https://github.com/YOU54F/pact-ruby-cli/pkgs/container/pact-cli