### PR TITLE
Deps/fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ADD docker/pact /usr/local/bin/pact
 
 RUN apk update \
   && apk add ruby=3.2.2-r0 \
-             ruby-bigdecimal=3.2.2-r0 \
              ruby-io-console=3.2.2-r0 \
              ca-certificates=20240226-r0 \
              libressl \
@@ -21,12 +20,13 @@ RUN apk update \
              ruby-dev=3.2.2-r0 \
              libressl-dev \
              ruby-rdoc=3.2.2-r0 \
-  && gem install bundler -v 2.4 \
+  && gem install bundler -v "~>2.5" \
   && bundler -v \
   && bundle config build.nokogiri --use-system-libraries \
   && bundle config git.allow_insecure true \
   && gem update --system \
   && gem install json -v "~>2.3" \
+  && gem install bigdecimal -v "~>3.1" \
   && gem cleanup \
   && apk del build-dependencies \
   && rm -rf /usr/lib/ruby/gems/*/cache/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update \
   && apk add ruby=3.2.2-r0 \
              ruby-bigdecimal=3.2.2-r0 \
              ruby-io-console=3.2.2-r0 \
-             ca-certificates=20230506-r0 \
+             ca-certificates=20240226-r0 \
              libressl \
              less \
              git \

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -50,7 +50,7 @@ ADD Gemfile .
 ADD Gemfile.lock .
 ADD lib/pact/cli/version.rb ./lib/pact/cli/version.rb
 RUN  bundle install --without test development --deployment true \
-      && find /usr/lib/ruby/gems/3.1.0/gems -name Gemfile.lock -maxdepth 2 -delete
+      && find /usr/lib/ruby/gems/3.2.0/gems -name Gemfile.lock -maxdepth 2 -delete
 ADD docker/entrypoint.sh $HOME/entrypoint.sh
 ADD bin ./bin
 ADD lib ./lib

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=18
-FROM node:${NODE_VERSION}-alpine3.17
+FROM node:${NODE_VERSION}-alpine3.18
 
 LABEL maintainer="Beth Skurrie <beth@bethesque.com>"
 
@@ -16,7 +16,6 @@ ADD docker/pact /usr/local/bin/pact
 
 RUN apk update \
   && apk add ruby \
-             ruby-bigdecimal \
              ruby-bundler \
              ruby-io-console \
              ca-certificates \
@@ -29,7 +28,7 @@ RUN apk update \
              libressl-dev \
              ruby-rdoc \
   \
-  && gem install bundler -v 2.4.12 \
+  && gem install bundler -v "~>2.5" \
   && bundler -v \
   && bundle config build.nokogiri --use-system-libraries \
   && bundle config git.allow_insecure true \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ PATH
   remote: .
   specs:
     pact-cli (1.1.0)
-      bigdecimal (= 3.1.3)
       json (~> 2.3)
       pact-mock_service
       pact-provider-verifier
@@ -20,7 +19,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.9.2)
-    bigdecimal (3.1.3)
+    bigdecimal (3.1.7)
     bump (0.10.0)
     coderay (1.1.3)
     diff-lcs (1.5.1)
@@ -137,4 +136,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.4.12
+   2.5.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
   remote: .
   specs:
     pact-cli (1.1.0)
+      bigdecimal (= 3.1.3)
       json (~> 2.3)
       pact-mock_service
       pact-provider-verifier
@@ -19,7 +20,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.9.2)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.3)
     bump (0.10.0)
     coderay (1.1.3)
     diff-lcs (1.5.1)

--- a/pact-cli.gemspec
+++ b/pact-cli.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pact-provider-verifier"
   spec.add_dependency "pact_broker-client", "~> 1.28"
   spec.add_dependency "json", "~>2.3" # must match native lib install in the Dockerfile
-  spec.add_dependency "bigdecimal", "3.1.3" # pin to std gem version https://stdgems.org/3.2.2/
 
   # Locking this until we have given rack-test 3.0 a good shake out in pure Ruby
   spec.add_dependency "rack-test", ">= 0.6.3", "< 2.0.0"

--- a/pact-cli.gemspec
+++ b/pact-cli.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pact-provider-verifier"
   spec.add_dependency "pact_broker-client", "~> 1.28"
   spec.add_dependency "json", "~>2.3" # must match native lib install in the Dockerfile
+  spec.add_dependency "bigdecimal", "3.1.3" # pin to std gem version https://stdgems.org/3.2.2/
 
   # Locking this until we have given rack-test 3.0 a good shake out in pure Ruby
   spec.add_dependency "rack-test", ">= 0.6.3", "< 2.0.0"


### PR DESCRIPTION
- cacerts required updating, as no longer avail
- bigdecimal required building from source, brought in via a transient dep, otherwise fails to build in 2nd stage of docker, as ruby-dev headers not found
- updates bundler to 2.5.9