### PR TITLE
Feat/rust tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM alpine:3.22.0
 
 LABEL maintainer="Beth Skurrie <beth@bethesque.com>"
 ARG TARGETPLATFORM
-ARG PLUGIN_CLI_VERSION=0.1.2
+ARG PLUGIN_CLI_VERSION=0.1.3
 ARG MOCK_SERVER_CLI_VERSION=1.0.6
-ARG VERIFIER_CLI_VERSION=1.1.3
-ARG STUB_SERVER_CLI_VERSION=0.6.0
+ARG VERIFIER_CLI_VERSION=1.2.0
+ARG STUB_SERVER_CLI_VERSION=0.6.2
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
@@ -76,14 +76,6 @@ RUN case ${TARGETPLATFORM} in \
     | gunzip -fc > ./bin/pact_verifier_cli && chmod +x ./bin/pact_verifier_cli \
     && wget -qO - https://github.com/pact-foundation/pact-core-mock-server/releases/download/pact_mock_server_cli-v1.0.6/pact_mock_server_cli-linux-${BIN_ARCH}.gz \
     | gunzip -fc > ./bin/pact_mock_server_cli && chmod +x ./bin/pact_mock_server_cli
-    # && wget -qO - https://github.com/pact-foundation/pact-stub-server/releases/download/v{STUB_SERVER_CLI_VERSION}/pact-stub-server-linux-${BIN_ARCH}.gz  \
-    # | gunzip -fc > ./bin/pact-stub-server-linux-${BIN_ARCH} && chmod +x ./bin/pact-stub-server \
-    # && wget -qO - https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${PLUGIN_CLI_VERSION}/pact-plugin-cli-linux-${BIN_ARCH}.gz \
-    # | gunzip -fc > ./bin/pact-plugin-cli && chmod +x ./bin/pact-plugin-cli  \
-    # && wget -qO - https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v{VERIFIER_CLI_VERSION}/pact_verifier_cli-linux-${BIN_ARCH}.gz \
-    # | gunzip -fc > ./bin/pact_verifier_cli && chmod +x ./bin/pact_verifier_cli \
-    # && wget -qO - https://github.com/pact-foundation/pact-core-mock-server/releases/download/pact_mock_server_cli-v{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-linux-${BIN_ARCH}.gz \
-    # | gunzip -fc > ./bin/pact_mock_server_cli && chmod +x ./bin/pact_mock_server_cli
 
 
 ENTRYPOINT ["/pact/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:3.22.0
 
 LABEL maintainer="Beth Skurrie <beth@bethesque.com>"
-
+ARG TARGETPLATFORM
+ARG PLUGIN_CLI_VERSION=0.1.2
+ARG MOCK_SERVER_CLI_VERSION=1.0.6
+ARG VERIFIER_CLI_VERSION=1.1.3
+ARG STUB_SERVER_CLI_VERSION=0.6.0
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 
@@ -59,6 +63,28 @@ ADD bin ./bin
 ADD lib ./lib
 ADD example/pacts ./example/pacts
 ADD example/provider-contracts ./example/provider-contracts
+
+RUN case ${TARGETPLATFORM} in \
+         "linux/amd64")  BIN_ARCH=x86_64  ;; \
+         "linux/arm64")  BIN_ARCH=aarch64  ;; \
+    esac \
+    && wget -qO - https://github.com/pact-foundation/pact-stub-server/releases/download/v0.6.0/pact-stub-server-linux-${BIN_ARCH}.gz \
+    | gunzip -fc > ./bin/pact-stub-server && chmod +x ./bin/pact-stub-server \
+    && wget -qO - https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v0.1.2/pact-plugin-cli-linux-${BIN_ARCH}.gz \
+    | gunzip -fc > ./bin/pact-plugin-cli && chmod +x ./bin/pact-plugin-cli  \
+    && wget -qO - https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v1.1.3/pact_verifier_cli-linux-${BIN_ARCH}.gz \
+    | gunzip -fc > ./bin/pact_verifier_cli && chmod +x ./bin/pact_verifier_cli \
+    && wget -qO - https://github.com/pact-foundation/pact-core-mock-server/releases/download/pact_mock_server_cli-v1.0.6/pact_mock_server_cli-linux-${BIN_ARCH}.gz \
+    | gunzip -fc > ./bin/pact_mock_server_cli && chmod +x ./bin/pact_mock_server_cli
+    # && wget -qO - https://github.com/pact-foundation/pact-stub-server/releases/download/v{STUB_SERVER_CLI_VERSION}/pact-stub-server-linux-${BIN_ARCH}.gz  \
+    # | gunzip -fc > ./bin/pact-stub-server-linux-${BIN_ARCH} && chmod +x ./bin/pact-stub-server \
+    # && wget -qO - https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${PLUGIN_CLI_VERSION}/pact-plugin-cli-linux-${BIN_ARCH}.gz \
+    # | gunzip -fc > ./bin/pact-plugin-cli && chmod +x ./bin/pact-plugin-cli  \
+    # && wget -qO - https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v{VERIFIER_CLI_VERSION}/pact_verifier_cli-linux-${BIN_ARCH}.gz \
+    # | gunzip -fc > ./bin/pact_verifier_cli && chmod +x ./bin/pact_verifier_cli \
+    # && wget -qO - https://github.com/pact-foundation/pact-core-mock-server/releases/download/pact_mock_server_cli-v{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-linux-${BIN_ARCH}.gz \
+    # | gunzip -fc > ./bin/pact_mock_server_cli && chmod +x ./bin/pact_mock_server_cli
+
 
 ENTRYPOINT ["/pact/entrypoint.sh"]
 CMD ["pact"]

--- a/docker-compose-verify-legacy.yml
+++ b/docker-compose-verify-legacy.yml
@@ -21,15 +21,9 @@ services:
       - GIT_COMMIT
       - GIT_BRANCH
     command: >
-      sh -c "
-      until wget -q --spider http://api:9292; do
-        sleep 1;
-      done;
-      /pact/entrypoint.sh verifier
-      --hostname api
-      --port 9292
-      --provider-name docker-example-provider
-      --provider-version ${GIT_COMMIT}
-      --provider-branch ${GIT_BRANCH}
-      --provider-tags ${GIT_BRANCH}
-      "
+      verify
+      --provider-base-url http://api:9292
+      --provider docker-example-provider
+      --provider-app-version ${GIT_COMMIT}
+      --provider-version-tag ${GIT_BRANCH}
+      --wait 20

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-PACT_COMMANDS=" broker help mock-service publish stub-service verify version "
+PACT_COMMANDS=" broker help mock-service publish stub-service verify version verifier mock-server stub-server plugin "
+# PACT_RUST_COMMANDS=" pact-plugin-cli pact-stub-server pact_mock_server_cli pact_verifier_cli "
 
 # git branch detection command fails due to cve fix https://github.blog/2022-04-12-git-security-vulnerability-announced/
 # fatal: unsafe repository (REPO is owned by someone else) in other workflow steps after running checkout
@@ -16,6 +17,8 @@ if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
   fi
 
   pact "$@"
+# elif [ -n "$1" ] && echo "$PACT_RUST_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
+#   exec "./bin/$@"
 else
   exec "$@"
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PACT_COMMANDS=" broker help mock-service publish stub-service verify version verifier mock-server stub-server plugin "
-# PACT_RUST_COMMANDS=" pact-plugin-cli pact-stub-server pact_mock_server_cli pact_verifier_cli "
+PACT_RUST_COMMANDS=" pact-plugin-cli pact-stub-server pact_mock_server_cli pact_verifier_cli "
 
 # git branch detection command fails due to cve fix https://github.blog/2022-04-12-git-security-vulnerability-announced/
 # fatal: unsafe repository (REPO is owned by someone else) in other workflow steps after running checkout
@@ -17,8 +17,8 @@ if [ -n "$1" ] && echo "$PACT_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
   fi
 
   pact "$@"
-# elif [ -n "$1" ] && echo "$PACT_RUST_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
-#   exec "./bin/$@"
+elif [ -n "$1" ] && echo "$PACT_RUST_COMMANDS" | grep -F " $1 " > /dev/null 2>&1 ; then
+  exec "./bin/$@"
 else
   exec "$@"
 fi

--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -95,18 +95,24 @@ module Pact
     desc 'mock-server', 'Run a Pact mock server'
     def mock_server
       ARGV.shift
-      output = `./bin/pact_mock_server_cli #{ARGV.join(" ")}`
-      exit_status = $?.exitstatus
-      puts output
-      exit(exit_status)
+      IO.popen(["./bin/pact_mock_server_cli", *ARGV], err: [:child, :out]) do |io|
+        while (line = io.gets)
+          $stdout.write(line)
+        end
+        exit_status = Process.wait2(io.pid)[1].exitstatus
+        exit(exit_status)
+      end
     end
     desc 'stub-server', 'Run a Pact stub server'
     def stub_server
       ARGV.shift
-      output = `./bin/pact-stub-server #{ARGV.join(" ")}`
-      exit_status = $?.exitstatus
-      puts output
-      exit(exit_status)
+      IO.popen(["./bin/pact-stub-server", *ARGV], err: [:child, :out]) do |io|
+        while (line = io.gets)
+          $stdout.write(line)
+        end
+        exit_status = Process.wait2(io.pid)[1].exitstatus
+        exit(exit_status)
+      end
     end
     no_commands do
       def self.exit_on_failure?

--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -25,12 +25,12 @@ module Pact
   class AggregatedCLI < Thor
     HELP = ["help", "--help", "-h"]
 
-    desc 'mock-service', 'Run a Pact mock service'
+    desc 'mock-service', '(legacy) Run a Pact mock service'
     def mock_service
       ::Pact::MockService::CLI.start(process_argv("mock-service"))
     end
 
-    desc 'stub-service', 'Run a Pact stub service'
+    desc 'stub-service', '(legacy) Run a Pact stub service'
     def stub_service
       require 'pact/stub_service/cli'
       Pact::StubService::CLI.start(process_argv("stub-service"))
@@ -51,7 +51,7 @@ module Pact
       ::Pactflow::Client::CLI::Pactflow.start(process_argv("pactflow"))
     end
 
-    desc 'verify PACT_URL ...', Pact::ProviderVerifier::CLI::Verify.commands["verify"].description
+    desc 'verify PACT_URL ...', "(legacy) " + Pact::ProviderVerifier::CLI::Verify.commands["verify"].description
     long_desc Pact::ProviderVerifier::CLI::Verify.commands["verify"].long_description
 
     def verify
@@ -76,7 +76,38 @@ module Pact
       require 'pact/cli/version'
       puts Pact::Cli::VERSION
     end
-
+    desc 'plugin', 'Run the Pact plugin cli'
+    def plugin
+      ARGV.shift
+      output = `./bin/pact-plugin-cli #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+    end
+    desc 'verifier', 'Run a Pact verifier'
+    def verifier
+      ARGV.shift
+      output = `./bin/pact_verifier_cli #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+    end
+    desc 'mock-server', 'Run a Pact mock server'
+    def mock_server
+      ARGV.shift
+      output = `./bin/pact_mock_server_cli #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+    end
+    desc 'stub-server', 'Run a Pact stub server'
+    def stub_server
+      ARGV.shift
+      output = `./bin/pact-stub-server #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+    end
     no_commands do
       def self.exit_on_failure?
         true


### PR DESCRIPTION
relates to https://github.com/pact-foundation/pact-ruby-standalone/pull/146

fixes #95

add rust tools to package

1. update `entrypoint.sh` to allow rust commands and delegate directly to them
2. update `cli.rb`  to allow entries in the main cli docs that run without a command. This means we can mark the ruby equiv tools as legacy, and prefer the use of the rust tools.

commands available via 

```
├── pact_mock_server_cli
├── pact-stub-server
├── pact_verifier_cli
└── pact-plugin-cli
```

or 

```
├── pact mock-server
├── pact stub-server
├── pact verifier
└── pact plugin
```

```
docker run --rm -it pact       
Commands:
   help [COMMAND]                  # Describe available commands or one specific command
   mock-server                     # Run a Pact mock server
   mock-service                    # (legacy) Run a Pact mock service
   pact-broker                     # Interact with a Pact Broker (also aliased as the subcommand `broker`)
   pactflow                        # Interact with PactFlow
   plugin                          # Run the Pact plugin cli
   publish PACT_DIRS_OR_FILES ...  # Publish pacts to a Pact Broker.
   stub-server                     # Run a Pact stub server
   stub-service                    # (legacy) Run a Pact stub service
   verifier                        # Run a Pact verifier
   verify PACT_URL ...             # (legacy) Verify pact(s) against a provider. Supports local and networked (http-based) files.
   version                         # Print the version of the CLI
```

Once merged, rename [pact-ruby-cli](https://github.com/pact-foundation/pact-ruby-cli) repo to pact-cli-docker