### PR TITLE
fix(deps): use rack-reverse-proxy pact-foundation fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,6 @@ group :development do
   gem 'conventional-changelog', '~> 1.3', git: 'https://github.com/bethesque/conventional-changelog-ruby.git', ref: 'feat/pact-foundation'
   gem 'bump', '~> 0.9'
 end
+
+gem 'rack-reverse-proxy', git: 'https://github.com/pact-foundation/rack-reverse-proxy.git',
+                          branch: 'feat/rack_2_and_3_compat'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,16 @@ GIT
   specs:
     conventional-changelog (1.3.0)
 
+GIT
+  remote: https://github.com/pact-foundation/rack-reverse-proxy.git
+  revision: 7ed51994123363a6969da5c6c89e04320715494b
+  branch: feat/rack_2_and_3_compat
+  specs:
+    rack-reverse-proxy (1.0.0.pre.unreleased)
+      rack (>= 3.0, < 4.0)
+      rack-proxy (~> 0.6, >= 0.6.1)
+      rackup (~> 2.0)
+
 PATH
   remote: .
   specs:
@@ -14,7 +24,7 @@ PATH
       pact-mock_service
       pact-provider-verifier
       pact_broker-client (~> 1.28)
-      rack-test (>= 0.6.3, < 2.0.0)
+      rack-test (>= 0.6.3, < 3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -111,16 +121,13 @@ GEM
     rack (3.1.8)
     rack-proxy (0.7.7)
       rack
-    rack-reverse-proxy (0.12.0)
-      rack (>= 1.0.0)
-      rack-proxy (~> 0.6, >= 0.6.1)
-    rack-test (0.6.3)
-      rack (>= 1.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
+    regexp_parser (2.9.3)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -157,6 +164,7 @@ DEPENDENCIES
   conventional-changelog (~> 1.3)!
   pact-cli!
   pry
+  rack-reverse-proxy!
   rake (~> 13.0)
   rspec (~> 3.0)
 

--- a/pact-cli.gemspec
+++ b/pact-cli.gemspec
@@ -47,8 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json", "~>2.8" # must match native lib install in the Dockerfile
   spec.add_dependency "bigdecimal", "~>3.1" # must match native lib install in the Dockerfile
 
-  # Locking this until we have given rack-test 3.0 a good shake out in pure Ruby
-  spec.add_dependency "rack-test", ">= 0.6.3", "< 2.0.0"
+  spec.add_dependency "rack-test", ">= 0.6.3", "< 3.0.0"
 
   spec.add_development_dependency "bump", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
- fixes issue #43

- updates to rack 3
  - enabled via https://github.com/pact-foundation/rack-reverse-proxy/tree/feat/rack_2_and_3_compat
- update to rack-test 2.1.0


## Reproduce

Create a simple ruby server, which returns a `set-cookie` header (Rack 3 so need to be lowercased)

```sh
require 'json'

class HttpRequestHandler
  def call(_env)
    response_body = JSON.generate(['foo'])
    [200, {
      'content-type' => 'application/json; charset=utf-8',
      'set-cookie' => '__cf_bm=_somebase64encodedstringwithequalsatthened=; array=awesome'
    }, [response_body]]
  end
end

run HttpRequestHandler.new
```

Save and run with `rackup -p 9393`

Save this following pact to `pact.json`

```json
{
    "consumer": {
      "name": "a"
    },
    "provider": {
      "name": "b"
    },
    "interactions": [
      {
        "description": "A request",
        "request": {
          "method": "GET",
          "path": "/",
          "headers": {
            "accept": "application/json"
          }
        },
        "response": {
          "status": 200,
          "headers": {
            "Content-Type": "application/json; charset=utf-8"
          },
          "body": ["foo"],
          "matchingRules": {
            "$.body": {
              "match": "type"
            }
          }
        }
      }
    ],
    "metadata": {
      "pactSpecification": {
        "version": "2.0.0"
      }
    }
  }
```

Run the verifier from the repo locally - passes


```
bundle exec bin/pact verify pact.json --provider-base-url http://localhost:9393 --verbose --log-level debug
```

Build the image

```
docker build -t pact-cli .
```

run it

```
docker run --rm -v $PWD:/test -it pact-cli verify /test/pact.json --provider-base-url http://host.docker.internal:9393 --verbose --log-level debug
```

passes - output

```
INFO: Reading pact at /test/pact.json


Verifying a pact between a and b
  A request
    with GET /
      returns a response which
        has status code 200
        has a matching body
        includes headers
          "Content-Type" which equals "application/json; charset=utf-8"

1 interaction, 0 failure
```

versus this which fails

```
docker run --rm -v $PWD:/test -it pactfoundation/pact-cli:1.3.0.11 verify /test/pact.json --provider-base-url http://host.docker.internal:9393 --verbose --log-level debug
```

error

```
     Failure/Error: replay_interaction interaction, options[:request_customizer]
     
     NoMethodError:
       undefined method `strip' for nil
     # ./bin/pact:15:in `<top (required)>'
```