### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,8 @@ name: Audit
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
   schedule:
     - cron: 0 0 * * 4 # Midnight Wednesday
 
@@ -14,7 +16,7 @@ jobs:
       matrix:
         DOCKER_TARGET_PLATFORM: [
           # linux/arm, # Disabled whilst waiting for next release of trivy with published arm artefacts
-          linux/arm64, 
+          linux/arm64,
           linux/amd64
           ]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   test:
@@ -23,7 +30,7 @@ jobs:
         node: [ 16, 18, 20 ]
     steps:
       - uses: actions/checkout@v4
-      
+
 
       - name: Login to Docker Hub
         run: script/release-workflow/docker-login.sh


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.