### PR TITLE
chore: update ca-certs / use arm builder for audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-latest-arm ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
     runs-on: ${{ matrix.os }}
     env:
       TAG: latest
@@ -26,7 +26,7 @@ jobs:
         env:
           DOCKER_TARGET_PLATFORM: linux/amd64
       - name: Audit Docker image for arm64
-        if: ${{ matrix.os }} == 'ubuntu-latest-arm'
+        if: ${{ matrix.os }} == 'ubuntu-24.04-arm'
         run: ./script/release-workflow/audit.sh
         env:
           DOCKER_TARGET_PLATFORM: linux/arm64

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,12 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Audit Docker image for amd64
-        if: ${{ matrix.os }} == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./script/release-workflow/audit.sh
         env:
           DOCKER_TARGET_PLATFORM: linux/amd64
       - name: Audit Docker image for arm64
-        if: ${{ matrix.os }} == 'ubuntu-24.04-arm'
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: ./script/release-workflow/audit.sh
         env:
           DOCKER_TARGET_PLATFORM: linux/arm64

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,19 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        DOCKER_TARGET_PLATFORM: [
-          # linux/arm, # Disabled whilst waiting for next release of trivy with published arm artefacts
-          linux/arm64,
-          linux/amd64
-          ]
-    runs-on: ubuntu-latest
+        os: [ ubuntu-latest, ubuntu-latest-arm ]
+    runs-on: ${{ matrix.os }}
     env:
-      DOCKER_TARGET_PLATFORM: ${{ matrix.DOCKER_TARGET_PLATFORM }}
       TAG: latest
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare Docker multi-arch builder for ${{ matrix.DOCKER_TARGET_PLATFORM }}
-        if: ${{ matrix.DOCKER_TARGET_PLATFORM }} == 'linux/arm' || 'linux/arm64'
-        run: ./script/release-workflow/docker-prepare.sh
-      - name: Audit Docker image for ${{ matrix.DOCKER_TARGET_PLATFORM }}
+      - name: Audit Docker image for amd64
+        if: ${{ matrix.os }} == 'ubuntu-latest'
         run: ./script/release-workflow/audit.sh
+        env:
+          DOCKER_TARGET_PLATFORM: linux/amd64
+      - name: Audit Docker image for arm64
+        if: ${{ matrix.os }} == 'ubuntu-latest-arm'
+        run: ./script/release-workflow/audit.sh
+        env:
+          DOCKER_TARGET_PLATFORM: linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD docker/pact /usr/local/bin/pact
 RUN apk update \
   && apk add ruby=3.3.6-r0 \
              ruby-io-console=3.3.6-r0 \
-             ca-certificates=20240705-r0 \
+             ca-certificates=20241121-r1 \
              libressl \
              less \
              git \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
   specs:
     awesome_print (1.9.2)
     base64 (0.2.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     bump (0.10.0)
     coderay (1.1.3)
     csv (3.3.0)
@@ -52,7 +52,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    json (2.9.0)
+    json (2.9.1)
     jsonpath (1.1.5)
       multi_json
     logger (1.6.2)


### PR DESCRIPTION
Arm runners now available, so may as well use them for the audit runs to speed them up

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Need to also apply to the main publishing runs to take advantage of the native arm64 runners
